### PR TITLE
align the way to calculate hash

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -410,7 +410,7 @@ func (engine *Engine) internalIndexDoc(docId string, data types.DocData,
 		atomic.AddUint64(&engine.numForceUpdatingReqs, 1)
 	}
 
-	hash := murmur.Sum32(fmt.Sprintf("%s%s", docId, data.Content))
+	hash := murmur.Sum32(docId)
 	engine.segmenterChan <- segmenterReq{
 		docId: docId, hash: hash, data: data, forceUpdate: forceUpdate}
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -706,7 +706,7 @@ func TestSearchNotUseGse(t *testing.T) {
 	tt.Expect(t, "2", len(outDocs))
 
 	tt.Expect(t, "8", outDocs[0].DocId)
-	tt.Expect(t, "3799", int(outDocs[0].Scores[0]*1000))
+	tt.Expect(t, "3999", int(outDocs[0].Scores[0]*1000))
 	tt.Expect(t, "[]", outDocs[0].TokenSnippetLocs)
 
 	outputs1 := engine1.Search(types.SearchReq{

--- a/engine_test.go
+++ b/engine_test.go
@@ -199,10 +199,10 @@ func TestFrequenciesIndex(t *testing.T) {
 	tt.Expect(t, "2", len(outDocs))
 
 	tt.Expect(t, "1", outDocs[0].DocId)
-	tt.Expect(t, "2374", int(outDocs[0].Scores[0]*1000))
+	tt.Expect(t, "2387", int(outDocs[0].Scores[0]*1000))
 
 	tt.Expect(t, "5", outDocs[1].DocId)
-	tt.Expect(t, "2133", int(outDocs[1].Scores[0]*1000))
+	tt.Expect(t, "2205", int(outDocs[1].Scores[0]*1000))
 
 	engine.Close()
 }
@@ -706,7 +706,7 @@ func TestSearchNotUseGse(t *testing.T) {
 	tt.Expect(t, "2", len(outDocs))
 
 	tt.Expect(t, "8", outDocs[0].DocId)
-	tt.Expect(t, "3736", int(outDocs[0].Scores[0]*1000))
+	tt.Expect(t, "3799", int(outDocs[0].Scores[0]*1000))
 	tt.Expect(t, "[]", outDocs[0].TokenSnippetLocs)
 
 	outputs1 := engine1.Search(types.SearchReq{

--- a/riot_test.go
+++ b/riot_test.go
@@ -40,11 +40,11 @@ func TestEngineIndexWithNewStore(t *testing.T) {
 	tt.Expect(t, "2", len(outDocs))
 
 	// tt.Expect(t, "2", outDocs[0].DocId)
-	tt.Expect(t, "2500", int(outDocs[0].Scores[0]*1000))
+	tt.Expect(t, "2531", int(outDocs[0].Scores[0]*1000))
 	tt.Expect(t, "[]", outDocs[0].TokenSnippetLocs)
 
 	// tt.Expect(t, "1", outDocs[1].DocId)
-	tt.Expect(t, "2215", int(outDocs[1].Scores[0]*1000))
+	tt.Expect(t, "2000", int(outDocs[1].Scores[0]*1000))
 	tt.Expect(t, "[]", outDocs[1].TokenSnippetLocs)
 
 	engine1.Close()


### PR DESCRIPTION
The pull request will be closed without any reasons if it does not satisfy any of following requirements:

1. Make sure you are targeting the `master` branch, pull requests on release branches are only allowed for bug fixes.
2. Please read contributing guidelines: [CONTRIBUTING](https://github.com/go-ego/riot/blob/master/CONTRIBUTING.md)
3. Describe what your pull request does and which issue you're targeting (if any and Please use English)
4. ... if it is not related to any particular issues, explain why we should not reject your pull request.
5. The Commits must use English, must be test and No useless submissions.

**You MUST delete the content above including this line before posting, otherwise your pull request will be invalid.**

## Description

The hash is used in [segment.go line 260](https://github.com/go-ego/riot/blob/6ed3775d67b6df082601a0d6491fe91e5c909b0e/segment.go#L260) to calculate shard index, rigth?

As calculate hash by both docid and content, if the content changes a bit then update the same docid's index, it will be highly possible assigned to another shard, so that there will be duplicated search result with same docid, which is not expected.
